### PR TITLE
Check password rather than setting it

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -13,7 +13,7 @@ set :bind, '0.0.0.0'
 
 if ENV['USERNAME'] && ENV['PASSWORD']
   use Rack::Auth::Basic, 'Demo area' do |user, pass|
-    user == ENV['USERNAME'] && pass = ENV['PASSWORD']
+    user == ENV['USERNAME'] && pass == ENV['PASSWORD']
   end
 end
 


### PR DESCRIPTION
If a username and password is set in the environment and someone guesses the username then they can use any password to log in.

Oops.

Corresponding PR on underlying repo: https://github.com/edds/display-screen/pull/6